### PR TITLE
Replace remote pip install with local

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_test.txt
 
-          pip install git+https://${{secrets.GH_TOKEN_MACHINE_USER}}@github.com/IDinsight/mosaiks@external_run_prep
+          pip install -e .
 
       - name: Run Unit Tests
         env:


### PR DESCRIPTION
## Context
Previously we had to use pip install on the branch `external_run_prep`. Now that it has been merged, we can replace with the standard local install which will use the latest version of each branch's code

Closes #85 