### PR TITLE
Update pyarrow version to 14.0.1

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,36 @@
+name: Publish Python Package
+
+on:
+  pull_request:
+    branches:
+    - main
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools build wheel twine requests
+
+    - name: Check for version update
+      run: |
+        python check_version.py
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m build --sdist
+        twine upload dist/*

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
     - main
-    tags:
-      - '*'
+    types: [closed]
 
 jobs:
-  deploy:
+  merge_job:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
     - uses: actions/checkout@v2
 

--- a/check_version.py
+++ b/check_version.py
@@ -1,0 +1,33 @@
+import importlib.util
+
+import requests
+
+
+def main():
+    # Get the latest version number from PyPI
+    url = "https://pypi.python.org/pypi/mosaiks/json"
+    response = requests.get(url)
+    latest_version = response.json()["info"]["version"]
+
+    # Get the installed version number
+    module = importlib.util.spec_from_file_location("mosaiks", "./mosaiks/__init__.py")
+    mosaiks = importlib.util.module_from_spec(module)
+    module.loader.exec_module(mosaiks)
+    installed_version = mosaiks.__version__
+
+    # Compare the two version numbers
+    if latest_version != installed_version:
+        print(
+            "You have updated the version of mosaiks to ({})".format(installed_version)
+        )
+    else:
+        print(
+            "You have not updated the version of mosaiks from ({})".format(
+                installed_version
+            )
+        )
+        raise AssertionError
+
+
+if __name__ == "__main__":
+    main()

--- a/mosaiks/__init__.py
+++ b/mosaiks/__init__.py
@@ -1,4 +1,4 @@
 from mosaiks.pipeline import get_features
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "IDinsight"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ dask-geopandas==0.3.1
 shapely==2.0.1
 pyproj==3.6.0
 pygeos==0.14
-pyarrow==12.0.1
+pyarrow==14.0.1
 
 ipykernel==6.24.0


### PR DESCRIPTION
There were security issues with the pyarrow v12 that we were using (flagged by Github to Utkarsh) so updating to v14. Ran pytests and demo notebook and everything still works.

Could we update pypi somehow too? Do we have that process automated through Github Actions maybe?